### PR TITLE
Bug 1155 - Fix UX Issues

### DIFF
--- a/app/Controllers/Http/ImageController.js
+++ b/app/Controllers/Http/ImageController.js
@@ -39,7 +39,7 @@ class ImageController {
       response.status(200).send({ url });
     } catch (err) {
       console.error(err.message);
-      response.status(500).send({ error: "Error uploading image" });
+      response.status(500).send({ error: err.message ?? "Error uploading image" });
     }
   }
 }

--- a/public/create-template.js
+++ b/public/create-template.js
@@ -29,8 +29,10 @@ $(document).ready(function(){
       $('#templateSubject').val(response.data.SubjectPart);
       $('#templateText').val(response.data.TextPart);
       window.codeMirrorEditor.setValue(response.data.HtmlPart ? response.data.HtmlPart : "");
-      $('#createTemplateForm').trigger('change'); //enable the save button
-      $('#createTemplateForm').trigger('input'); //enable the save button
+
+      //enable the save button
+      $('#createTemplateForm').trigger('change'); 
+      $('#createTemplateForm').trigger('input');
     });
   }
 
@@ -52,7 +54,6 @@ $(document).ready(function(){
       data: createPayload,
       success: function() {
         $(window).unbind('beforeunload');
-
         window.location.href = '/';
       },
       error: function(xhr) {

--- a/public/create-template.js
+++ b/public/create-template.js
@@ -17,6 +17,11 @@ $(document).ready(function(){
     }
   );
 
+  // observe any changes to the form. If so, then enable the create btn
+  $('#createTemplateForm').on('input', () => {
+    $('#createTemplateForm button').attr('disabled', false);
+  });
+
   if (urlParams.has('d-origin')) {
     // we need to load the existing template from which we will duplicate
     $.get(`/get-template/${urlParams.get('d-origin')}?region=${localStorage.getItem('region')}`, function (response) {
@@ -25,13 +30,9 @@ $(document).ready(function(){
       $('#templateText').val(response.data.TextPart);
       window.codeMirrorEditor.setValue(response.data.HtmlPart ? response.data.HtmlPart : "");
       $('#createTemplateForm').trigger('change'); //enable the save button
+      $('#createTemplateForm').trigger('input'); //enable the save button
     });
   }
-
-  // observe any changes to the form. If so, then enable the create btn
-  $('#createTemplateForm').on('input', () => {
-    $('#createTemplateForm button').attr('disabled', false);
-  });
 
   // handle form submissions
   $('#createTemplateForm').submit(function(e) {
@@ -51,7 +52,7 @@ $(document).ready(function(){
       data: createPayload,
       success: function() {
         $(window).unbind('beforeunload');
-        
+
         window.location.href = '/';
       },
       error: function(xhr) {

--- a/public/create-template.js
+++ b/public/create-template.js
@@ -50,6 +50,8 @@ $(document).ready(function(){
       url: "/create-template",
       data: createPayload,
       success: function() {
+        $(window).unbind('beforeunload');
+        
         window.location.href = '/';
       },
       error: function(xhr) {

--- a/public/global.js
+++ b/public/global.js
@@ -2,6 +2,7 @@ const currentVersion = "v1.5.4";
 
 let previousFillVarsText = "";
 let templateName = "";
+let fieldChanged = false;
 
 const parseJSONText = (jsonText) => {
   return JSON.parse(jsonText || "{}");
@@ -9,7 +10,6 @@ const parseJSONText = (jsonText) => {
 
 // updates email Live Preview
 const onCodeMirrorChange = (editor) => {
-
   $("#templatePreview").attr("srcDoc", editor.getValue());
 
   // get variables enclosed with {} from editor
@@ -225,5 +225,16 @@ function populateTextSectionContent() {
     $("#fillVariablesClose").click(onFillVarsClose);
     $("#fillVarsModal").on("hidden.bs.modal", onFillVarsClose);
     $("#fillVarsModal").on("shown.bs.modal", onFillVarsOpen);
+
+    $(window).bind('beforeunload', function(){
+      if (window.location.pathname.match(/\/(create-template|update-template)\/?$/)) {
+          // returning a value that is not null will trigger the native browser confirm dialog.
+          // in Chrome and Edge, it will be "Changes you made may not be saved."
+          // For Firefox, it will be "This page is asking you to confirm that you want to leave - data you have entered may not be saved."
+          // On advantage of this is the ability to run code even when refreshing the page.
+
+          return true;
+        }
+    });
   });
 })();

--- a/public/global.js
+++ b/public/global.js
@@ -2,7 +2,6 @@ const currentVersion = "v1.5.4";
 
 let previousFillVarsText = "";
 let templateName = "";
-let fieldChanged = false;
 
 const parseJSONText = (jsonText) => {
   return JSON.parse(jsonText || "{}");
@@ -34,6 +33,11 @@ const onCodeMirrorChange = (editor) => {
     onFillVarsSave();
   }, 1);
 };
+
+// for paste event, auto enable submit button
+const onCodeMirrorInputRead = () => {
+  $('#updateTemplateForm button').attr('disabled', false);
+}
 
 const onFillVarsOpen = () => {
   this.fillVarsCodeMirrorEditor.refresh();
@@ -107,6 +111,7 @@ function listenToCodeMirror() {
     const newFillVarsText = JSON.stringify(lcFillVars[templateName] || {}, null, 2);
 
     editor.on("change", onCodeMirrorChange);
+    editor.on("inputRead", onCodeMirrorInputRead);
     varsEditor.on("change", onFillVarsChange);
 
     window.fillVarsCodeMirrorEditor.setValue(newFillVarsText);

--- a/public/global.js
+++ b/public/global.js
@@ -9,6 +9,7 @@ const parseJSONText = (jsonText) => {
 
 // updates email Live Preview
 const onCodeMirrorChange = (editor) => {
+
   $("#templatePreview").attr("srcDoc", editor.getValue());
 
   // get variables enclosed with {} from editor
@@ -236,10 +237,13 @@ function populateTextSectionContent() {
           // returning a value that is not null will trigger the native browser confirm dialog.
           // in Chrome and Edge, it will be "Changes you made may not be saved."
           // For Firefox, it will be "This page is asking you to confirm that you want to leave - data you have entered may not be saved."
-          // On advantage of this is the ability to run code even when refreshing the page.
+          // An advantage of this is the ability to run code even when refreshing the page.
 
           return true;
         }
+
+        // editor is not open -- no need to warn user
+        return null;
     });
   });
 })();

--- a/public/global.js
+++ b/public/global.js
@@ -156,7 +156,7 @@ function onUploadImageChange({ target: { files } }) {
     success: function ({ url, error }) {
       // catches both null and undefined
       if (url == null || !!error) {
-        onError();
+        onUploadImageError(error);
         return;
       }
 

--- a/public/global.js
+++ b/public/global.js
@@ -121,6 +121,12 @@ function onUploadImageClick(e) {
   e.preventDefault();
 }
 
+function showError(title, message) {
+  $('#errorModal .modal-title').text(title)
+  $('#errorModal .modal-body').text(message)
+  $('#errorModal').modal('show');
+}
+
 // When the uploadImage input is changed, upload the new image right away
 function onUploadImageChange({ target: { files } }) {
   const formData = new FormData();
@@ -134,6 +140,12 @@ function onUploadImageChange({ target: { files } }) {
   formData.append("file", files[0]);
   formData.append("region", localStorage.getItem("region"));
 
+  const onUploadImageError = (message) => {
+    const defaultContent = "Error uploading image. Please try again.";
+
+    showError(defaultContent, message ?? defaultContent);
+  }
+
   $.ajax({
     type: "POST",
     url: "/upload-image",
@@ -141,22 +153,20 @@ function onUploadImageChange({ target: { files } }) {
     contentType: false,
     processData: false,
 
-    success: function ({ url }) {
+    success: function ({ url, error }) {
+      // catches both null and undefined
+      if (url == null || !!error) {
+        onError();
+        return;
+      }
+
       const editor = window.codeMirrorEditor;
 
       editor.replaceSelection(`<img src="${url}" alt="">`);
     },
 
     error: function (xhr) {
-      let content;
-
-      if (xhr.responseJSON.message) {
-        content = xhr.responseJSON.message;
-      } else {
-        content = "Error uploading image. Please try again.";
-      }
-
-      $("#errContainer").html(content).removeClass("d-none");
+      onUploadImageError(xhr.responseJSON?.error);
     },
   });
 }

--- a/public/update-template.js
+++ b/public/update-template.js
@@ -50,6 +50,7 @@ $(document).ready(() => {
       type: 'PUT',
       data: putPayload,
       success: function() {
+        $(window).unbind('beforeunload');
         window.location.href = '/';
       },
       error: function(xhr) {

--- a/resources/views/components/error-modal.edge
+++ b/resources/views/components/error-modal.edge
@@ -1,0 +1,18 @@
+<div id="errorModal" class="modal" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title text-danger"></h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-dismiss="modal">Ok</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/resources/views/create-template.edge
+++ b/resources/views/create-template.edge
@@ -23,6 +23,7 @@
 
   <body>
     @!component('components.header')
+    @!component('components.error-modal')
 
     <div class="container">
       <div class="row pt-3">

--- a/resources/views/update-template.edge
+++ b/resources/views/update-template.edge
@@ -23,6 +23,7 @@
 
   <body>
     @!component('components.header')
+    @!component('components.error-modal')
 
     <div class="container">
       <div class="row pt-3">


### PR DESCRIPTION
1. Fix Image upload issues, now an error dialog appears when uploading image fails. Issue #2 
2. Leaving or refreshing the editor page will warn the user "Unsaved changes will be lost ", native browser based approach is used. Issue #3 
3. Duplicating a template will leave the `Create` button enabled in case an exact copy is needed. Copy/pasting will automatically enable the `Update` button while editing a template. Issue #9 